### PR TITLE
fixed CPP template plugin

### DIFF
--- a/template/cpp/integrationplugintemplate.cpp
+++ b/template/cpp/integrationplugintemplate.cpp
@@ -42,7 +42,7 @@ void  IntegrationPluginExample::setupThing(ThingSetupInfo *info)
 
 void IntegrationPluginExample::executeAction(ThingActionInfo *info)
 {
-    qCDebug(dcTemplate()) << "Executing action for thing" << info->thing()->name() << action.actionTypeId().toString() << action.params();
+    qCDebug(dcTemplate()) << "Executing action for thing" << info->thing()->name() << info->action().actionTypeId().toString() << info->action().params();
 
     info->finish(Thing::ThingErrorNoError);
 }

--- a/template/cpp/integrationplugintemplate.h
+++ b/template/cpp/integrationplugintemplate.h
@@ -34,7 +34,7 @@ class IntegrationPluginExample: public IntegrationPlugin
 
 
 public:
-    explicit DevicePluginExample();
+    explicit IntegrationPluginExample();
 
     void init() override;
 


### PR DESCRIPTION
Renamed constructor to IntegrationPluginExample
Fixed issue in executeAction to allow an error-free build